### PR TITLE
refactor, use limma for testing of factor ~ group associations

### DIFF
--- a/R/R_functions.R
+++ b/R/R_functions.R
@@ -135,13 +135,7 @@ ard_nmf <- function(A, k_init = 2, n_replicates = 3, tol = 1e-5, cv_tol = 1e-4, 
   for (curr_rep in 1:n_replicates) {
     if (verbose >= 1 && n_replicates > 1) cat("\nREPLICATE ", curr_rep, "/", n_replicates, "\n")
     step_size <- 1
-    if (nrow(df) == 0) {
-      # start at the specified rank
-      curr_rank <- k_init
-    } else {
-      # start at the current best rank
-      curr_rank <- GetBestRank(df)
-    }
+    curr_rank <- k_init
     max_rank <- ncol(A)
     while (step_size >= 1 && curr_rank < ncol(A)) {
       # as long as we are at a rank less than the rank of the matrix and step size is 1 or greater, continue trying to find the best rank

--- a/R/R_functions.R
+++ b/R/R_functions.R
@@ -27,6 +27,9 @@ run_nmf <- function(A, rank, tol = 1e-4, maxit = 100, verbose = TRUE, L1 = 0.01,
   model$d <- model$d[sort_index]
   model$w <- t(model$w)[, sort_index]
   model$h <- model$h[sort_index, ]
+  rownames(model$w) <- rownames(A)
+  colnames(model$h) <- colnames(A)
+  colnames(model$w) <- rownames(model$h) <- paste0("NMF_", 1:ncol(model$w))
   model
 }
 
@@ -210,6 +213,9 @@ ard_nmf <- function(A, k_init = 2, n_replicates = 3, tol = 1e-5, cv_tol = 1e-4, 
   model$d <- model$d[sort_index]
   model$w <- t(model$w)[, sort_index]
   model$h <- model$h[sort_index, ]
+  rownames(model$w) <- rownames(A)
+  colnames(model$h) <- colnames(A)
+  colnames(model$w) <- rownames(model$h) <- paste0("NMF_", 1:ncol(model$w))
   model
 }
 

--- a/R/Seurat_wrapper.R
+++ b/R/Seurat_wrapper.R
@@ -10,7 +10,8 @@
 #' @param k an initial rank at which to start automatic cross-validation, or a vector of ranks at which to fit.
 #' @param reps number of replicates for cross-validation
 #' @param test.set.density approximate density of the test set (default 0.05)
-#' @param tol tolerance of the fit (correlation distance of the model across consecutive iterations). Cross-validation fits are 10x coarser than this tolerance.
+#' @param tol tolerance of the final fit (correlation distance of the model across consecutive iterations). 
+#' @param cv.tol tolerance of the fit during cross-validation
 #' @param maxit maximum number of fitting iterations
 #' @param L1 L1/LASSO penalty to increase sparsity of the model
 #' @param L2 L2/Ridge-like penalty to increase angles between factors
@@ -33,6 +34,7 @@ RunNMF.Seurat <- function(object,
                           assay = NULL,
                           reps = 3,
                           tol = 1e-5,
+                          cv.tol = 1e-4,
                           L1 = 0.01,
                           L2 = 0,
                           verbose = 2,
@@ -75,7 +77,7 @@ RunNMF.Seurat <- function(object,
   if (length(k) > 1) {
     # run cross-validation at specified ranks
     cv_data <- data.frame()
-    cv_data <- cross_validate_nmf(A, k, reps, tol * 10, maxit, verbose, L1, L2, threads, test.set.density, tol.overfit, trace.test.mse, 2)
+    cv_data <- cross_validate_nmf(A, k, reps, cv.tol, maxit, verbose, L1, L2, threads, test.set.density, tol.overfit, trace.test.mse, 2)
     best_rank <- GetBestRank(cv_data)
     if (verbose >= 1) {
       cat("best rank: ", best_rank, "\n")
@@ -84,7 +86,7 @@ RunNMF.Seurat <- function(object,
     nmf_model <- run_nmf(A, best_rank, tol, maxit, verbose > 1, L1, L2, threads)
   } else if (length(k) == 1) {
     # run automatic rank determination cross-validation
-    nmf_model <- ard_nmf(A, k, reps, tol, maxit, verbose, L1, L2, threads, test.set.density, learning.rate, tol.overfit, trace.test.mse, 2)
+    nmf_model <- ard_nmf(A, k, reps, tol, cv.tol, maxit, verbose, L1, L2, threads, test.set.density, learning.rate, tol.overfit, trace.test.mse, 2)
     cv_data <- nmf_model$cv_data
   } else {
     stop("value for 'k' was invalid")

--- a/R/Seurat_wrapper.R
+++ b/R/Seurat_wrapper.R
@@ -330,6 +330,7 @@ RunLNMF.Seurat <- function(object,
   # balancing step.
   # not sure if this is a good idea.
   if (link.balance.tol != 1 & link.balance.tol != 0) {
+    At <- t(A)
     lnmf_model$w <- t(lnmf_model$w)
     if (verbose > 0) {
       cat("balancing...\n")
@@ -362,7 +363,7 @@ RunLNMF.Seurat <- function(object,
         }
       }
       # run linked nmf
-      lnmf_model <- c_nmf(A, At, tol, 1L, FALSE, L1, L2, threads, lnmf_model$w, link_h, 1, 0)
+      lnmf_model <- c_linked_nmf(A, At, tol, 1L, FALSE, L1, L2, threads, w, lnmf_model$w, link_h)
       m <- MetadataSummary(lnmf_model$h, split.by, FALSE)
       v <- as.vector(abs(1 / length(levels) - m))
       curr.balance.tol <- mean(v[v != 0 & v != 1])
@@ -470,7 +471,7 @@ AnnotateNMF.Seurat <- function(object, fields = NULL, reduction = "nmf", ...){
 #' 
 AnnotationPlot.DimReduc <- function(object, plot.field = NULL, ...){
   if(!("annotations" %in% names(object@misc))){
-    stop("the ", reduction, " reduction of this object has no 'annotations' slot. Run 'AnnotateNMF' first.")
+    stop("the reduction has no 'annotations' slot. Run 'AnnotateNMF' first.")
   }
   if(is.null(plot.field)){
     plot.field <- names(object@misc$annotations)[[1]]

--- a/R/Seurat_wrapper.R
+++ b/R/Seurat_wrapper.R
@@ -470,16 +470,16 @@ AnnotationPlot.DimReduc <- function(object, plot.field = NULL, ...){
   if(!("annotations" %in% names(object@misc))){
     stop("the ", reduction, " reduction of this object has no 'annotations' slot. Run 'AnnotateNMF' first.")
   }
-  if(is.null(field)){
-    field <- names(object@misc$annotations)[[1]]
+  if(is.null(plot.field)){
+    plot.field <- names(object@misc$annotations)[[1]]
   } else {
-    if(!(field %in% names(object@misc$annotations))){
-      stop("specified field was not in the annotation object")
+    if(!(plot.field %in% names(object@misc$annotations))){
+      stop("specified plot.field was not in the annotation object")
     }
-    if(length(field) > 1) field <- field[[1]]
+    if(length(plot.field) > 1) plot.field <- plot.field[[1]]
   }
   # construct a matrix of pvalues and fc
-  ann <- object@misc$annotations[[field]]
+  ann <- object@misc$annotations[[plot.field]]
   pvals <- reshape(ann, timevar = "group", idvar = "factor", direction = "wide", drop = "fc")
   fc <- reshape(ann, timevar = "group", idvar = "factor", direction = "wide", drop = "p")
   rownames(pvals) <- pvals[,1]
@@ -505,7 +505,7 @@ AnnotationPlot.DimReduc <- function(object, plot.field = NULL, ...){
                            geom_point() + 
                            scale_color_viridis_c(option = "B", end = 0.9) + 
                            theme_classic() + 
-                           labs(y = field, x = "NMF factor", color = "p-value\n(-log10)", size = "fold enrichment") + 
+                           labs(y = plot.field, x = "NMF factor", color = "p-value\n(-log10)", size = "fold enrichment") + 
                            theme(axis.text.x = element_text(angle = 45, hjust = 1, vjust = 1))))
 }
 

--- a/R/Seurat_wrapper.R
+++ b/R/Seurat_wrapper.R
@@ -61,8 +61,13 @@ RunNMF.Seurat <- function(object,
     object <- PreprocessData(object, assay = assay)
   }
   A <- object@assays[[assay]]@data
-  rnames <- rownames(A)
-  cnames <- colnames(A)
+  if(prod(dim(object@assays[[assay]]@counts)) != 0){
+    rnames <- rownames(object@assays[[assay]]@counts)
+    cnames <- colnames(object@assays[[assay]]@counts)
+  } else {
+    rnames <- rownames(object@assays[[assay]]@data)
+    cnames <- colnames(object@assays[[assay]]@data)
+  }
 
   if (!is.null(split.by)) {
     split.by <- as.integer(as.numeric(as.factor(object@meta.data[[split.by]]))) - 1

--- a/man/RunNMF.Rd
+++ b/man/RunNMF.Rd
@@ -12,6 +12,7 @@
   assay = NULL,
   reps = 3,
   tol = 1e-05,
+  cv.tol = 1e-04,
   L1 = 0.01,
   L2 = 0,
   verbose = 2,
@@ -39,7 +40,9 @@ RunNMF(object, ...)
 
 \item{reps}{number of replicates for cross-validation}
 
-\item{tol}{tolerance of the fit (correlation distance of the model across consecutive iterations). Cross-validation fits are 10x coarser than this tolerance.}
+\item{tol}{tolerance of the final fit (correlation distance of the model across consecutive iterations).}
+
+\item{cv.tol}{tolerance of the fit during cross-validation}
 
 \item{L1}{L1/LASSO penalty to increase sparsity of the model}
 

--- a/man/ard_nmf.Rd
+++ b/man/ard_nmf.Rd
@@ -9,6 +9,7 @@ ard_nmf(
   k_init = 2,
   n_replicates = 3,
   tol = 1e-05,
+  cv_tol = 1e-04,
   maxit = 100,
   verbose = 1,
   L1 = 0.01,
@@ -28,7 +29,9 @@ ard_nmf(
 
 \item{n_replicates}{number of random test sets}
 
-\item{tol}{tolerance of the fit (1e-5 for publication quality, 1e-3 for cross-validation)}
+\item{tol}{tolerance of the final fit}
+
+\item{cv_tol}{tolerance for cross-validation}
 
 \item{maxit}{maximum number of iterations}
 

--- a/src/singlet.cpp
+++ b/src/singlet.cpp
@@ -386,7 +386,7 @@ Rcpp::S4 log_normalize(Rcpp::SparseMatrix A_, const unsigned int scale_factor, c
   
     // log-transform
     for(Rcpp::SparseMatrix::InnerIterator it(A, i); it; ++it)
-      it.value() = std::log1p(it.value() * scale_factor);
+      it.value() = std::log1p(it.value() * norm);
   }
   return A.wrap();
 }

--- a/vignettes/Guided_Clustering_with_NMF.Rmd
+++ b/vignettes/Guided_Clustering_with_NMF.Rmd
@@ -42,13 +42,14 @@ pbmc3k[["percent.mt"]] <- PercentageFeatureSet(pbmc3k, pattern = "^MT-")
 pbmc3k <- subset(pbmc3k, subset = nFeature_RNA > 200 & nFeature_RNA < 2500 & percent.mt < 5)
 ```
 
-Now run NMF cross-validation and learn the model at the (automatically determined) best rank:
+Now run NMF cross-validation and learn the model at the (automatically determined) best rank, then annotate the model with available metadata, which in this case is cell types:
 
 ```{R, results = 'hide', message = FALSE, warning = FALSE, cross-validation}
 set.seed(123)
-pbmc3k <- NormalizeData(pbmc3k) %>%
-  singlet::RunNMF()
+pbmc3k <- PreprocessData(pbmc3k) %>% RunNMF() %>% AnnotateNMF()
 ```
+
+Remember to set the seed, as above, to guarantee reproducibility of your NMF model.
 
 Plot the cross-validation results:
 
@@ -56,7 +57,17 @@ Plot the cross-validation results:
 RankPlot(pbmc3k)
 ```
 
-Remember to set the seed, as above, to guarantee reproducibility of your NMF model.
+You can also look at the iteration-level results:
+
+```{R}
+RankPlot(pbmc3k, detail = 2)
+```
+
+Plot the annotation results for `cell_type`, since `cell_type` is a factor in the `@meta.data` slot of the Seurat object:
+
+```{R}
+AnnotationPlot(pbmc3k)
+```
 
 ## Visualization
 


### PR DESCRIPTION
This will likely need to be a painful manual merge, but should probably be done given how much faster and more robust limma is for the one-vs-all contrasts.  The default shrinkage is universally more powerful than marginal t-tests as a bonus. 